### PR TITLE
Add support for describing structs

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -12,6 +12,8 @@ pub trait Describer: Sized {
     type Ok;
     type Error;
 
+    type DescribeStruct: DescribeStruct<Ok = Self::Ok, Error = Self::Error>;
+
     fn describe_bool(self) -> Result<Self::Ok, Self::Error>;
     fn describe_i8(self) -> Result<Self::Ok, Self::Error>;
     fn describe_i16(self) -> Result<Self::Ok, Self::Error>;
@@ -56,5 +58,13 @@ pub trait Describer: Sized {
         K: Describe,
         V: Describe;
 
-    fn describe_struct(self, name: TypeName) -> Result<Self::Ok, Self::Error>;
+    fn describe_struct(self, name: TypeName) -> Result<Self::DescribeStruct, Self::Error>;
+}
+
+pub trait DescribeStruct {
+    type Ok;
+    type Error;
+
+    fn describe_field<T: Describe>(&mut self, name: &'static str) -> Result<(), Self::Error>;
+    fn end(self) -> Result<Self::Ok, Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
 mod describe;
 mod primitive;
 mod schema;
@@ -9,4 +12,22 @@ pub use crate::{describe::*, schema::*, schema_describer::*};
 pub fn describe<T: Describe>() -> Result<Schema, ()> {
     let mut describe = SchemaDescriber;
     T::describe(&mut describe)
+}
+
+/// Unique name for a type.
+///
+/// All types are uniquely identified by a combination of their name and the module
+/// in which they were declared; Since two types with the same name cannot be
+/// declared in the same module, `TypeName` is always sufficient to disambiguate
+/// between two types with the same name.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TypeName {
+    /// The local name of the type.
+    pub name: Cow<'static, str>,
+
+    /// The path to the module where the type is declared, starting with the crate name.
+    ///
+    /// Note that this may not be the same module that the type is publicly exported
+    /// from in the owning crate.
+    pub module: Cow<'static, str>,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,3 +1,4 @@
+use crate::TypeName;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
@@ -57,6 +58,7 @@ pub struct NewtypeStruct {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Struct {
     pub name: TypeName,
+    pub fields: Vec<(Cow<'static, str>, Schema)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -67,24 +69,6 @@ pub struct Enum {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TupleStruct {
     pub name: TypeName,
-}
-
-/// Unique name for a type.
-///
-/// All types are uniquely identified by a combination of their name and the module
-/// in which they were declared; Since two types with the same name cannot be
-/// declared in the same module, `TypeName` is always sufficient to disambiguate
-/// between two types with the same name.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct TypeName {
-    /// The local name of the type.
-    pub name: Cow<'static, str>,
-
-    /// The path to the module where the type is declared, starting with the crate name.
-    ///
-    /// Note that this may not be the same module that the type is publicly exported
-    /// from in the owning crate.
-    pub module: Cow<'static, str>,
 }
 
 /// Expands to a [`TypeName`] for the specified type.

--- a/tests/describe_struct.rs
+++ b/tests/describe_struct.rs
@@ -1,0 +1,34 @@
+use schematic::*;
+
+struct ManualDescribeImpl {
+    _field: String,
+    _another: u32,
+}
+
+impl Describe for ManualDescribeImpl {
+    fn describe<D: Describer>(describer: D) -> std::result::Result<D::Ok, D::Error> {
+        let mut describer = describer.describe_struct(schematic::type_name!(ManualDescribeImpl))?;
+        describer.describe_field::<String>("_field")?;
+        describer.describe_field::<u32>("_another")?;
+        describer.end()
+    }
+}
+
+#[test]
+fn describe_struct() {
+    let actual = schematic::describe::<ManualDescribeImpl>()
+        .expect("Failed to describe `ManualDescribeImpl`");
+
+    let expected = Schema::Struct(Box::new(Struct {
+        name: TypeName {
+            name: "ManualDescribeImpl".into(),
+            module: "describe_struct".into(),
+        },
+        fields: vec![
+            ("_field".into(), Schema::String),
+            ("_another".into(), Schema::U32),
+        ],
+    }));
+
+    assert_eq!(expected, actual);
+}


### PR DESCRIPTION
* Add `DescribeStruct` trait and update relevant parts of `Describer`.
* Add fields to `Struct`.
* Add test verifying that a manual implementation of `Describe` for a struct works.