### PR TITLE
Describe simple enums

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -5,11 +5,11 @@ use std::borrow::Cow;
 /// In-memory representation of a type tree.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Schema {
-    Struct(Box<Struct>),
+    Struct(Struct),
     UnitStruct(UnitStruct),
     NewtypeStruct(Box<NewtypeStruct>),
     TupleStruct(TupleStruct),
-    Enum(Box<Enum>),
+    Enum(Enum),
     Option(Box<Schema>),
     Seq(Box<Schema>),
     Tuple(Vec<Schema>),
@@ -38,7 +38,14 @@ pub enum Schema {
 impl Schema {
     pub fn as_struct(&self) -> Option<&Struct> {
         match self {
-            Schema::Struct(inner) => Some(&**inner),
+            Schema::Struct(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn as_enum(&self) -> Option<&Enum> {
+        match self {
+            Schema::Enum(inner) => Some(inner),
             _ => None,
         }
     }
@@ -64,6 +71,56 @@ pub struct Struct {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Enum {
     pub name: TypeName,
+
+    /// The explicit representation of the enum, as specified by the `#[repr(...)]`
+    /// attribute.
+    ///
+    /// `None` if the 
+    pub repr: Option<Primitive>,
+    pub variants: Vec<Variant>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Variant {
+    Unit {
+        name: Cow<'static, str>,
+        discriminant: Option<PrimitiveValue>,
+    },
+
+    Struct(Struct),
+    Tuple(Vec<Schema>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Primitive {
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    Usize,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    Isize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PrimitiveValue {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+    Usize(usize),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    I128(i128),
+    Isize(isize),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/schema_describer.rs
+++ b/src/schema_describer.rs
@@ -1,7 +1,7 @@
 use crate::{
     describe::{Describe, Describer},
     schema::*,
-    DescribeStruct, TypeName,
+    DescribeEnum, DescribeStruct, DescribeTuple, TypeName,
 };
 use std::borrow::Cow;
 
@@ -12,6 +12,8 @@ impl<'a> Describer for &'a mut SchemaDescriber {
     type Error = ();
 
     type DescribeStruct = StructDescriber;
+    type DescribeEnum = EnumDescriber;
+    type DescribeTuple = TupleDescriber;
 
     fn describe_bool(self) -> Result<Self::Ok, Self::Error> {
         Ok(Schema::Bool)
@@ -100,11 +102,11 @@ impl<'a> Describer for &'a mut SchemaDescriber {
         })))
     }
 
-    fn describe_enum<T>(self, _name: TypeName) -> Result<Self::Ok, Self::Error>
-    where
-        T: Describe,
-    {
-        unimplemented!()
+    fn describe_enum(self, type_name: TypeName) -> Result<Self::DescribeEnum, Self::Error> {
+        Ok(EnumDescriber {
+            type_name,
+            variants: Vec::new(),
+        })
     }
 
     fn describe_tuple(self) -> Result<Self::Ok, Self::Error> {
@@ -154,9 +156,83 @@ impl DescribeStruct for StructDescriber {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        Ok(Schema::Struct(Box::new(Struct {
+        Ok(Schema::Struct(Struct {
             name: self.type_name,
             fields: self.fields,
-        })))
+        }))
+    }
+}
+
+pub struct TupleDescriber {
+    elements: Vec<Schema>,
+}
+
+impl DescribeTuple for TupleDescriber {
+    type Ok = Schema;
+    type Error = ();
+
+    fn describe_element<T: Describe>(&mut self) -> Result<(), Self::Error> {
+        self.elements.push(crate::describe::<T>()?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Schema::Tuple(self.elements))
+    }
+}
+
+pub struct EnumDescriber {
+    type_name: TypeName,
+    variants: Vec<Variant>,
+}
+
+impl DescribeEnum for EnumDescriber {
+    type Ok = Schema;
+    type Error = ();
+
+    type DescribeStruct = StructDescriber;
+    type DescribeTuple = TupleDescriber;
+
+    fn describe_unit_variant(
+        &mut self,
+        name: &'static str,
+        discriminant: Option<PrimitiveValue>,
+    ) -> Result<(), Self::Error> {
+        self.variants.push(Variant::Unit {
+            name: name.into(),
+            discriminant,
+        });
+
+        Ok(())
+    }
+
+    fn start_tuple_variant(
+        &mut self,
+        name: &'static str,
+    ) -> Result<Self::DescribeTuple, Self::Error> {
+        unimplemented!()
+    }
+
+    fn end_tuple_variant(&mut self, variant: Self::DescribeTuple) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+
+    fn start_struct_variant(
+        &mut self,
+        name: &'static str,
+    ) -> Result<Self::DescribeStruct, Self::Error> {
+        unimplemented!()
+    }
+
+    fn end_struct_variant(&mut self, variant: Self::DescribeStruct) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Schema::Enum(Enum {
+            name: self.type_name,
+            repr: None,
+            variants: self.variants,
+        }))
     }
 }

--- a/src/schema_describer.rs
+++ b/src/schema_describer.rs
@@ -208,23 +208,23 @@ impl DescribeEnum for EnumDescriber {
 
     fn start_tuple_variant(
         &mut self,
-        name: &'static str,
+        _name: &'static str,
     ) -> Result<Self::DescribeTuple, Self::Error> {
         unimplemented!()
     }
 
-    fn end_tuple_variant(&mut self, variant: Self::DescribeTuple) -> Result<(), Self::Error> {
+    fn end_tuple_variant(&mut self, _variant: Self::DescribeTuple) -> Result<(), Self::Error> {
         unimplemented!()
     }
 
     fn start_struct_variant(
         &mut self,
-        name: &'static str,
+        _name: &'static str,
     ) -> Result<Self::DescribeStruct, Self::Error> {
         unimplemented!()
     }
 
-    fn end_struct_variant(&mut self, variant: Self::DescribeStruct) -> Result<(), Self::Error> {
+    fn end_struct_variant(&mut self, _variant: Self::DescribeStruct) -> Result<(), Self::Error> {
         unimplemented!()
     }
 

--- a/tests/describe_enum.rs
+++ b/tests/describe_enum.rs
@@ -1,5 +1,6 @@
 use schematic::*;
 
+#[allow(dead_code)]
 enum Simple {
     Foo,
     Bar,

--- a/tests/describe_enum.rs
+++ b/tests/describe_enum.rs
@@ -1,0 +1,37 @@
+use schematic::*;
+
+enum Simple {
+    Foo,
+    Bar,
+}
+
+impl Describe for Simple {
+    fn describe<D: Describer>(describer: D) -> std::result::Result<D::Ok, D::Error> {
+        let mut describer = describer.describe_enum(schematic::type_name!(Simple))?;
+        describer.describe_unit_variant("Foo", None)?;
+        describer.describe_unit_variant("Bar", None)?;
+        describer.end()
+    }
+}
+
+#[test]
+fn describe_simple_enum() {
+    let actual = schematic::describe::<Simple>().expect("Failed to describe `Simple`");
+
+    let expected = Schema::Enum(Enum {
+        name: type_name!(Simple),
+        repr: None,
+        variants: vec![
+            Variant::Unit {
+                name: "Foo".into(),
+                discriminant: None,
+            },
+            Variant::Unit {
+                name: "Bar".into(),
+                discriminant: None,
+            },
+        ],
+    });
+
+    assert_eq!(expected, actual);
+}

--- a/tests/describe_struct.rs
+++ b/tests/describe_struct.rs
@@ -19,7 +19,7 @@ fn describe_struct() {
     let actual = schematic::describe::<ManualDescribeImpl>()
         .expect("Failed to describe `ManualDescribeImpl`");
 
-    let expected = Schema::Struct(Box::new(Struct {
+    let expected = Schema::Struct(Struct {
         name: TypeName {
             name: "ManualDescribeImpl".into(),
             module: "describe_struct".into(),
@@ -28,7 +28,7 @@ fn describe_struct() {
             ("_field".into(), Schema::String),
             ("_another".into(), Schema::U32),
         ],
-    }));
+    });
 
     assert_eq!(expected, actual);
 }


### PR DESCRIPTION
* Add `DescribeEnum` and `DescribeTuple` helper traits.
* Add `EnumDescriber` and `TupleDescriber` helper types for the built-in schema generation.
* Implement the schema description functionality for unit variants.

This PR fully implements support for tuples with all unit variants. It also includes a sketch of the API for tuple variants and struct variants, though they're not fully implemented yet.