### PR TITLE
Improve type name handling

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -2,6 +2,9 @@ use crate::{PrimitiveValue, TypeName};
 
 // A *data structure* that can be described by schematic.
 pub trait Describe: Sized {
+    // The unique name identifying the type.
+    fn type_name() -> TypeName;
+
     fn describe<D>(describer: D) -> Result<D::Ok, D::Error>
     where
         D: Describer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,13 @@ pub struct TypeName {
     /// Note that this may not be the same module that the type is publicly exported
     /// from in the owning crate.
     pub module: Cow<'static, str>,
+
+    /// Any generic parameters, if the type is generic.
+    ///
+    /// For non-generic types, this list will be empty. For generic types, this list
+    /// should reflect the names of each of the generic parameters in order of
+    /// declaration.
+    pub type_params: Vec<TypeName>,
 }
 
 impl TypeName {
@@ -93,6 +100,20 @@ impl TypeName {
         Self {
             name: name.into(),
             module: module.into(),
+            type_params: Vec::new(),
+        }
+    }
+
+    pub fn generic<N, M, P>(name: N, module: M, type_params: P) -> Self
+    where
+        N: Into<Cow<'static, str>>,
+        M: Into<Cow<'static, str>>,
+        P: Into<Vec<TypeName>>,
+    {
+        Self {
+            name: name.into(),
+            module: module.into(),
+            type_params: type_params.into(),
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -60,10 +60,7 @@ impl Schema {
     /// use schematic::{Schema, Struct, TypeName};
     ///
     /// let schema = Schema::Struct(Struct {
-    ///     name: TypeName {
-    ///         name: "MyStruct".into(),
-    ///         module: "my_crate::my_module".into(),
-    ///     },
+    ///     name: TypeName::new("MyStruct", "my_crate::my_module"),
     ///     fields: vec![],
     /// });
     ///
@@ -491,10 +488,6 @@ impl fmt::Display for PrimitiveValue {
 #[macro_export]
 macro_rules! type_name {
     ($ty:ty) => {
-        $crate::TypeName {
-            // TODO: Support stripping off
-            name: std::borrow::Cow::Borrowed(stringify!($ty)),
-            module: std::borrow::Cow::Borrowed(module_path!()),
-        }
+        $crate::TypeName::new(stringify!($ty), module_path!())
     };
 }

--- a/tests/collections.rs
+++ b/tests/collections.rs
@@ -1,10 +1,10 @@
 use pretty_assertions::assert_eq;
-use schematic::{Array, Schema, Sequence, TypeName};
+use schematic::{Array, Describe, Schema, Sequence, TypeName};
 
 #[test]
 fn describe_vec() {
     let expected = Schema::Seq(Box::new(Sequence {
-        name: TypeName::new("Vec", "alloc::vec"),
+        name: TypeName::generic("Vec", "alloc::vec", vec![<u32 as Describe>::type_name()]),
         element: Schema::U32,
         len: None,
     }));

--- a/tests/describe_enum.rs
+++ b/tests/describe_enum.rs
@@ -8,8 +8,12 @@ enum Simple {
 }
 
 impl Describe for Simple {
+    fn type_name() -> TypeName {
+        schematic::type_name!(Simple)
+    }
+
     fn describe<D: Describer>(describer: D) -> std::result::Result<D::Ok, D::Error> {
-        let mut describer = describer.describe_enum(schematic::type_name!(Simple))?;
+        let mut describer = describer.describe_enum(Self::type_name())?;
         describer.describe_unit_variant("Foo", None)?;
         describer.describe_unit_variant("Bar", None)?;
         describer.end()
@@ -46,8 +50,12 @@ enum WithData {
 }
 
 impl Describe for WithData {
+    fn type_name() -> TypeName {
+        schematic::type_name!(WithData)
+    }
+
     fn describe<D: Describer>(describer: D) -> std::result::Result<D::Ok, D::Error> {
-        let mut describer = describer.describe_enum(schematic::type_name!(WithData))?;
+        let mut describer = describer.describe_enum(Self::type_name())?;
 
         describer.describe_unit_variant("Foo", None)?;
 

--- a/tests/describe_struct.rs
+++ b/tests/describe_struct.rs
@@ -7,8 +7,12 @@ pub struct ManualStruct {
 }
 
 impl Describe for ManualStruct {
+    fn type_name() -> TypeName {
+        schematic::type_name!(ManualStruct)
+    }
+
     fn describe<D: Describer>(describer: D) -> Result<D::Ok, D::Error> {
-        let mut describer = describer.describe_struct(schematic::type_name!(ManualStruct))?;
+        let mut describer = describer.describe_struct(Self::type_name())?;
         describer.describe_field::<bool>("field")?;
         describer.describe_field::<u32>("another")?;
         describer.end()
@@ -33,9 +37,12 @@ fn describe_struct() {
 pub struct ManualTupleStruct(bool, u32);
 
 impl Describe for ManualTupleStruct {
+    fn type_name() -> TypeName {
+        schematic::type_name!(ManualTupleStruct)
+    }
+
     fn describe<D: Describer>(describer: D) -> Result<D::Ok, D::Error> {
-        let mut describer =
-            describer.describe_tuple_struct(schematic::type_name!(ManualTupleStruct))?;
+        let mut describer = describer.describe_tuple_struct(Self::type_name())?;
         describer.describe_element::<bool>()?;
         describer.describe_element::<u32>()?;
         describer.end()
@@ -68,8 +75,12 @@ pub struct NestedStruct {
 }
 
 impl Describe for NestedStruct {
+    fn type_name() -> TypeName {
+        schematic::type_name!(NestedStruct)
+    }
+
     fn describe<D: Describer>(describer: D) -> Result<D::Ok, D::Error> {
-        let mut describer = describer.describe_struct(schematic::type_name!(NestedStruct))?;
+        let mut describer = describer.describe_struct(Self::type_name())?;
         describer.describe_field::<ManualStruct>("manual_struct")?;
         describer.describe_field::<ManualTupleStruct>("tuple_struct")?;
         describer.end()


### PR DESCRIPTION
This PR makes two changes to make `TypeName` more useful:

* Add a `type_name` associated function to the `Describe` trait to directly get the type name for any type implementing `Describe`. As as result, all primitive types now have an associated type name.
* Add a `type_params` field to `TypeName` to ensure that different monomorphizations of a generic type can be differentiated by their type name (as described in #12).

Together these changes make it easier to use `TypeName` to uniformly reference a type without needing to fully describe a type.

Closes #12